### PR TITLE
don't depend on the whole AWS sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-s3</artifactId>
             <version>${aws-sdk-java.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This has been a problem for me, why should this library depend on all AWS services' SDK? I managed to reduce the dependencies to the sole S3 service. That's a lot less jars.
